### PR TITLE
Remove use of `Windows.Storage` in Server project

### DIFF
--- a/src/HotCorner.Server/HotCorner.Server.vcxproj
+++ b/src/HotCorner.Server/HotCorner.Server.vcxproj
@@ -127,6 +127,7 @@
   <ItemGroup>
     <ClInclude Include="Resources.h" />
     <ClInclude Include="server.h" />
+    <ClInclude Include="Storage\AppData.h" />
     <ClInclude Include="Tracking\CornerActions.h" />
     <ClInclude Include="Tracking\CornerTracker.h" />
     <ClInclude Include="LifetimeManager.h" />
@@ -140,6 +141,7 @@
     <ClInclude Include="Undocumented\UxTheme.h" />
   </ItemGroup>
   <ItemGroup>
+    <ClCompile Include="Storage\AppData.cpp" />
     <ClCompile Include="Tracking\CornerActions.cpp" />
     <ClCompile Include="Tracking\CornerTracker.cpp" />
     <ClCompile Include="LifetimeManager.cpp" />

--- a/src/HotCorner.Server/HotCorner.Server.vcxproj.filters
+++ b/src/HotCorner.Server/HotCorner.Server.vcxproj.filters
@@ -25,6 +25,9 @@
     <ClCompile Include="Tracking\CornerActions.cpp">
       <Filter>Tracking</Filter>
     </ClCompile>
+    <ClCompile Include="Storage\AppData.cpp">
+      <Filter>Storage</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="Tray\TrayIcon.h">
@@ -64,6 +67,9 @@
     <ClInclude Include="server.h">
       <Filter>Server</Filter>
     </ClInclude>
+    <ClInclude Include="Storage\AppData.h">
+      <Filter>Storage</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <None Include="vcpkg.json">
@@ -94,6 +100,9 @@
     </Filter>
     <Filter Include="Project Files">
       <UniqueIdentifier>{7f28ff92-db39-4965-8240-9c18049db232}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Storage">
+      <UniqueIdentifier>{d780e4b4-9ddf-438b-b58d-2a01bb8d419f}</UniqueIdentifier>
     </Filter>
   </ItemGroup>
   <ItemGroup>

--- a/src/HotCorner.Server/Storage/AppData.cpp
+++ b/src/HotCorner.Server/Storage/AppData.cpp
@@ -6,7 +6,7 @@
 #include <wil/resource.h>
 
 namespace winrt::HotCorner::Server::AppData {
-	static bool IsPackaged() {
+	static bool IsPackaged() noexcept {
 		UINT32 length = 0;
 		const LONG result = GetCurrentPackageFullName(&length, nullptr);
 

--- a/src/HotCorner.Server/Storage/AppData.cpp
+++ b/src/HotCorner.Server/Storage/AppData.cpp
@@ -1,0 +1,37 @@
+#include "pch.h"
+#include "AppData.h"
+
+#include <appmodel.h>
+#include <ShlObj_core.h>
+#include <wil/resource.h>
+
+namespace winrt::HotCorner::Server::AppData {
+	static bool IsPackaged() {
+		UINT32 length = 0;
+		const LONG result = GetCurrentPackageFullName(&length, nullptr);
+
+		return result != APPMODEL_ERROR_NO_PACKAGE;
+	}
+
+	std::optional<std::filesystem::path> Roaming() {
+		if (IsPackaged()) {
+			wil::unique_cotaskmem_string path{};
+			const auto hr = SHGetKnownFolderPath(
+				FOLDERID_RoamingAppData,
+				KF_FLAG_FORCE_APP_DATA_REDIRECTION,
+				nullptr,
+				path.put()
+			);
+
+			if (hr != S_OK) {
+				//TODO: Handle failure
+				OutputDebugString(L"Unable to get current Local AppData folder path\n");
+				return std::nullopt;
+			}
+
+			return path.get();
+		}
+
+		return std::nullopt;
+	}
+}

--- a/src/HotCorner.Server/Storage/AppData.h
+++ b/src/HotCorner.Server/Storage/AppData.h
@@ -1,0 +1,11 @@
+#pragma once
+#include <filesystem>
+#include <optional>
+
+namespace winrt::HotCorner::Server::AppData {
+	/**
+	 * @brief Gets the path to the app's Roaming folder. This method expects a packaged
+	 *        environment - if the expectation fails, nullopt is returned.
+	*/
+	std::optional<std::filesystem::path> Roaming();
+}

--- a/src/HotCorner.Server/main.cpp
+++ b/src/HotCorner.Server/main.cpp
@@ -20,7 +20,7 @@ namespace winrt::HotCorner::Server::Current {
 	}
 
 	static Settings::SettingsManager m_settings{ GetSettingsPath() };
-	Settings::SettingsManager& Settings() {
+	Settings::SettingsManager& Settings() noexcept {
 		return m_settings;
 	}
 

--- a/src/HotCorner.Server/main.cpp
+++ b/src/HotCorner.Server/main.cpp
@@ -3,30 +3,33 @@
 #include "server.h"
 
 #include "LifetimeManager.h"
+#include "Storage/AppData.h"
 #include "Tracking/TrayCornerTracker.h"
-#include <winrt/Windows.Storage.h>
 
 namespace winrt::HotCorner::Server::Current {
 	static HINSTANCE m_instance = nullptr;
-
 	HINSTANCE Module() noexcept {
 		return m_instance;
 	}
 
+	static std::filesystem::path GetSettingsPath() {
+		if (const auto path = AppData::Roaming()) {
+			return *path;
+		}
+		throw_hresult(APPMODEL_ERROR_NO_PACKAGE);
+	}
+
+	static Settings::SettingsManager m_settings{ GetSettingsPath() };
 	Settings::SettingsManager& Settings() {
-		static Settings::SettingsManager m_settings{
-			Windows::Storage::ApplicationData::Current().LocalFolder().Path().c_str()
-		};
 		return m_settings;
 	}
 
 	extern "C" int WINAPI wWinMain(HINSTANCE instance, HINSTANCE, PWSTR pCmdLine, int) {
+		winrt::init_apartment(apartment_type::multi_threaded);
 		if (!m_instance) {
 			m_instance = instance;
-			Settings().Load();
+			m_settings.Load();
 		}
-
-		winrt::init_apartment(apartment_type::multi_threaded);
 
 		DWORD cookie{};
 		server::register_class<implementation::LifetimeManager>(&cookie);
@@ -36,11 +39,11 @@ namespace winrt::HotCorner::Server::Current {
 		// If auto startup is enabled, we won't get this argument, which means
 		// we have to initialize tracking right away
 		if (wcscmp(pCmdLine, L"-Embedding") != 0) {
-			if (Settings().TrackingEnabled) {
+			if (m_settings.TrackingEnabled) {
 				TrackHotCorners();
 			}
 
-			if (Settings().TrayIconEnabled) {
+			if (m_settings.TrayIconEnabled) {
 				ShowTrayIcon();
 			}
 		}

--- a/src/HotCorner.Server/main.h
+++ b/src/HotCorner.Server/main.h
@@ -7,5 +7,5 @@ namespace winrt::HotCorner::Server::Current {
 	/**
 	 * @brief Gets the singleton instance of the current settings manager.
 	*/
-	Settings::SettingsManager& Settings();
+	Settings::SettingsManager& Settings() noexcept;
 }

--- a/src/HotCorner.Uwp/AppSettings.cpp
+++ b/src/HotCorner.Uwp/AppSettings.cpp
@@ -5,7 +5,7 @@
 namespace winrt::HotCorner::Uwp {
 	Settings::SettingsManager& AppSettings() {
 		static Settings::SettingsManager m_settings{
-			Windows::Storage::ApplicationData::Current().LocalFolder().Path().c_str()
+			Windows::Storage::ApplicationData::Current().RoamingFolder().Path().c_str()
 		};
 		return m_settings;
 	}


### PR DESCRIPTION
This removes the dependency on `Windows.Storage` from the Server project, to avoid possible reliability issues (WASDK 101 comes to mind).