### PR TITLE
Fix 1809 compat

### DIFF
--- a/src/HotCorner.Server/HotCorner.Server.manifest
+++ b/src/HotCorner.Server/HotCorner.Server.manifest
@@ -2,15 +2,36 @@
 <assembly
 	xmlns="urn:schemas-microsoft-com:asm.v1"
 	manifestVersion="1.0"
+	xmlns:compatv1="urn:schemas-microsoft-com:compatibility.v1"
 	xmlns:asmv3="urn:schemas-microsoft-com:asm.v3"
 	xmlns:ws2016="http://schemas.microsoft.com/SMI/2016/WindowsSettings"
 	xmlns:ws2020="http://schemas.microsoft.com/SMI/2020/WindowsSettings">
 
 	<dependency>
 		<dependentAssembly>
-			<assemblyIdentity type="win32" name="Microsoft.Windows.Common-Controls" version="6.0.0.0" processorArchitecture="*" publicKeyToken="6595b64144ccf1df" language="*" />
+			<assemblyIdentity
+				type="win32"
+				name="Microsoft.Windows.Common-Controls"
+				version="6.0.0.0"
+				processorArchitecture="*"
+				publicKeyToken="6595b64144ccf1df"
+				language="*" />
 		</dependentAssembly>
 	</dependency>
+
+	<asmv3:trustInfo>
+		<security>
+			<requestedPrivileges>
+				<requestedExecutionLevel level="asInvoker" uiAccess="false" />
+			</requestedPrivileges>
+		</security>
+	</asmv3:trustInfo>
+
+	<compatv1:compatibility>
+		<application>
+			<supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}" />
+		</application>
+	</compatv1:compatibility>
 
 	<asmv3:application>
 		<windowsSettings>

--- a/src/HotCorner.Server/HotCorner.Server.vcxproj
+++ b/src/HotCorner.Server/HotCorner.Server.vcxproj
@@ -139,6 +139,7 @@
     <ClInclude Include="Tray\WindowBase.h" />
     <ClInclude Include="Tray\WindowClass.h" />
     <ClInclude Include="Undocumented\UxTheme.h" />
+    <ClInclude Include="Version.h" />
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="Storage\AppData.cpp" />
@@ -152,6 +153,7 @@
     <ClCompile Include="Tray\TrayIcon.cpp" />
     <ClCompile Include="Tracking\TrayCornerTracker.cpp" />
     <ClCompile Include="Undocumented\UxTheme.cpp" />
+    <ClCompile Include="Version.cpp" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />

--- a/src/HotCorner.Server/HotCorner.Server.vcxproj.filters
+++ b/src/HotCorner.Server/HotCorner.Server.vcxproj.filters
@@ -28,6 +28,7 @@
     <ClCompile Include="Storage\AppData.cpp">
       <Filter>Storage</Filter>
     </ClCompile>
+    <ClCompile Include="Version.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="Tray\TrayIcon.h">
@@ -70,6 +71,7 @@
     <ClInclude Include="Storage\AppData.h">
       <Filter>Storage</Filter>
     </ClInclude>
+    <ClInclude Include="Version.h" />
   </ItemGroup>
   <ItemGroup>
     <None Include="vcpkg.json">

--- a/src/HotCorner.Server/Undocumented/UxTheme.cpp
+++ b/src/HotCorner.Server/Undocumented/UxTheme.cpp
@@ -1,10 +1,16 @@
 #include "pch.h"
 #include "UxTheme.h"
 
+#include <Version.h>
 #include <wil/resource.h>
 
 namespace winrt::HotCorner::Server::Undocumented {
 	ShellTheme GetCurrentShellTheme() noexcept {
+		// Before 1903, the default shell theme was dark, no light mode
+		if (!IsAtLeast1903()) {
+			return ShellTheme::Dark;
+		}
+
 		// https://github.com/TranslucentTB/TranslucentTB/blob/0726b0afbdf83eb579537d59bb36076a9071ec06/TranslucentTB/dynamicloader.hpp#L26C4-L26C4
 		static wil::unique_hmodule m_UxTheme{};
 		m_UxTheme.reset(LoadLibraryEx(L"uxtheme.dll", nullptr, LOAD_LIBRARY_SEARCH_SYSTEM32));

--- a/src/HotCorner.Server/Version.cpp
+++ b/src/HotCorner.Server/Version.cpp
@@ -1,0 +1,14 @@
+#include "pch.h"
+#include "Version.h"
+
+#include <winrt/Windows.Foundation.Metadata.h>
+
+namespace wfm = winrt::Windows::Foundation::Metadata;
+
+namespace winrt::HotCorner::Server {
+	bool IsAtLeast1903() noexcept {
+		return wfm::ApiInformation::IsApiContractPresent(
+			L"Windows.Foundation.UniversalApiContract", 8
+		);
+	}
+}

--- a/src/HotCorner.Server/Version.h
+++ b/src/HotCorner.Server/Version.h
@@ -1,0 +1,8 @@
+#pragma once
+
+namespace winrt::HotCorner::Server {
+	/**
+	 * @brief Returns whether the user is on Windows 10 1903, or a future version.
+	*/
+	bool IsAtLeast1903() noexcept;
+}


### PR DESCRIPTION
Under Windows 10 1809, `ShouldSystemUseDarkMode` does not exist. Trying to invoke the method below 1903 is bound to cause trouble, so maybe don't do that. Light shell theme was added on 1903, so there is no need to worry about tray icon visibility for the time being.